### PR TITLE
Simplify partner route type to avoid complex union

### DIFF
--- a/src/app/api/partners/route.ts
+++ b/src/app/api/partners/route.ts
@@ -164,20 +164,12 @@ export async function POST(req: NextRequest) {
       savedPartner._id
     );
 
-    // --- 9. Type Assertion for savedPartner._id ---
-    // Assert that the saved document includes _id as an ObjectId
-    const savedPartnerTyped = savedPartner as IServerListing & {
-      _id: mongoose.Types.ObjectId;
-    };
-
-    // --- 10. Construct Return Data ---
     const result: ApiPartnerData = {
-      id: savedPartnerTyped._id.toString(),
-      name: savedPartnerTyped.discord_server_name,
-      inviteLink: savedPartnerTyped.discord_invite_link,
+      id: savedPartner.id,
+      name: savedPartner.discord_server_name,
+      inviteLink: savedPartner.discord_invite_link,
     };
 
-    // --- 9. Return Success Response ---
     return NextResponse.json(
       { message: 'Partner created successfully', partner: result },
       { status: 201 }


### PR DESCRIPTION
## Summary
- simplify saved partner typing in partners API to reduce complex union

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `npm run prettier:check` *(fails: Code style issues found in 47 files)*
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b46c7c8b78832fa8fb1ac8b8d13f33