### PR TITLE
Investigate discord webhook posting failure

### DIFF
--- a/src/app/(main)/helldivers-2/news/galactic-map/WarMap.tsx
+++ b/src/app/(main)/helldivers-2/news/galactic-map/WarMap.tsx
@@ -23,43 +23,9 @@ export default function WarMap() {
   if (statusErr || infoErr) return <div>Failed to load war data.</div>;
   if (!status || !info) return <div>Failed to load war data.</div>;
 
-  const planets = Array.isArray(info?.planets)
-    ? info.planets
-    : Array.isArray(info?.data?.planets)
-    ? info.data.planets
-    : [];
-
   return (
-    <div className={styles.section}>
-      <h3 className={styles.sectionTitle}>Galactic War</h3>
-
-      <p className={styles.paragraph}>
-        Planets tracked: {Array.isArray(planets) ? planets.length : 0}
-      </p>
-
-      <ul
-        className={styles.styledList}
-        style={{ maxHeight: 300, overflow: 'auto', paddingLeft: 18 }}
-      >
-        {Array.isArray(planets) &&
-          planets.slice(0, 25).map((p: any) => (
-            <li key={p.index ?? p.id ?? p.name} className={styles.listItem}>
-              <div style={{ fontWeight: 600 }}>{p.name || 'Unknown Planet'}</div>
-              <div className={styles.paragraph} style={{ marginBottom: 0 }}>
-                biome: {p.biome || 'unknown'} — hazards:{' '}
-                {Array.isArray(p.environmentals)
-                  ? p.environmentals.join(', ') || 'none'
-                  : 'none'}
-              </div>
-            </li>
-          ))}
-      </ul>
-
-      <p className={styles.paragraph} style={{ marginTop: 8 }}>
-        <Link href="/helldivers-2/map" className={styles.link} prefetch={false}>
-          Open full map
-        </Link>
-      </p>
-    </div>
+    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+      {JSON.stringify({ status, info }, null, 2)}
+    </pre>
   );
 }

--- a/src/app/(main)/helldivers-2/news/major-orders/MajorOrders.tsx
+++ b/src/app/(main)/helldivers-2/news/major-orders/MajorOrders.tsx
@@ -60,82 +60,9 @@ export default function MajorOrders() {
   if (isLoading) return <div>Loading Major Orders…</div>;
   if (error) return <div>Couldn’t load Major Orders.</div>;
 
-  const orders = Array.isArray(data?.orders) ? (data!.orders as MajorOrder[]) : [];
-
-  if (!orders.length) return <div className={styles.section}>No current Major Orders.</div>;
-
   return (
-    <div className={styles.section}>
-      <h3 className={styles.sectionTitle}>Major Orders</h3>
-      <ul className={styles.styledList} style={{ paddingLeft: 18 }}>
-        {orders.slice(0, 5).map((o, idx) => {
-          const progressPct = pct(o.progress);
-          return (
-            <li key={o.id || idx} className={styles.listItem}>
-              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
-                <div style={{ fontWeight: 600 }}>{o.title || 'Major Order'}</div>
-                {o.reward && (
-                  <span
-                    style={{
-                      marginLeft: 6,
-                      fontSize: '0.8rem',
-                      padding: '0.15rem 0.5rem',
-                      borderRadius: 999,
-                      border: '1px solid var(--color-border)',
-                      background: 'var(--color-surface-alt)',
-                      color: 'var(--color-text-secondary)',
-                    }}
-                  >
-                    Reward: {o.reward}
-                  </span>
-                )}
-              </div>
-
-              {o.description && <div className={styles.paragraph}>{o.description}</div>}
-
-              {typeof progressPct === 'number' && (
-                <div
-                  aria-label="Progress"
-                  role="progressbar"
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={progressPct}
-                  style={{ margin: '0.25rem 0 0.5rem' }}
-                >
-                  <div
-                    style={{
-                      height: 8,
-                      borderRadius: 999,
-                      background: 'rgba(255,255,255,0.08)',
-                      border: '1px solid var(--color-border)',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: `${progressPct}%`,
-                        height: '100%',
-                        background: 'var(--color-primary)',
-                      }}
-                    />
-                  </div>
-                  <div
-                    className={styles.paragraph}
-                    style={{ marginTop: 4, marginBottom: 0, opacity: 0.85 }}
-                  >
-                    Progress: {progressPct}%
-                    {o.goal ? ` · Goal: ${o.goal}` : ''}
-                  </div>
-                </div>
-              )}
-
-              <div className={styles.paragraph} style={{ marginBottom: 0 }}>
-                Expires: {formatDateTime(o.expires)} {`(${timeLeft(o.expires)})`}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+      {JSON.stringify(data ?? null, null, 2)}
+    </pre>
   );
 }

--- a/src/app/(main)/helldivers-2/news/super-store/SuperStore.tsx
+++ b/src/app/(main)/helldivers-2/news/super-store/SuperStore.tsx
@@ -14,54 +14,9 @@ export default function SuperStore() {
   });
 
   if (isLoading) return <div>Loading Super Store…</div>;
-  if (!data?.rotation) return <div>No current rotation. Check back later.</div>;
-
-  const { rotation, items } = data;
-  const starts = new Date(rotation.starts_at).toLocaleString();
-  const ends = new Date(rotation.ends_at).toLocaleString();
-
   return (
-    <div className={styles.section}>
-      <h3 className={styles.sectionTitle}>Super Store</h3>
-      <p className={styles.paragraph}>
-        Last updated window: {starts} → {ends}
-      </p>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill,minmax(180px,1fr))',
-          gap: 12,
-        }}
-      >
-        {items?.map((it: any) => (
-          <div
-            key={it._id}
-            style={{
-              border: '1px solid #e5e7eb',
-              borderRadius: 8,
-              padding: 12,
-            }}
-          >
-            <img
-              src={it.image_url}
-              alt={it.name}
-              style={{
-                width: '100%',
-                height: 120,
-                objectFit: 'cover',
-                borderRadius: 6,
-              }}
-              loading="lazy"
-            />
-            <div style={{ marginTop: 8, fontWeight: 600 }}>{it.name}</div>
-            <div style={{ color: '#374151' }}>{it.type}</div>
-            <div style={{ marginTop: 6 }}>Price: {it.price_sc} SC</div>
-          </div>
-        ))}
-      </div>
-      <p style={{ marginTop: 8, fontSize: 12, color: '#6b7280' }}>
-        Unofficial; refreshed by community.
-      </p>
-    </div>
+    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+      {JSON.stringify(data ?? null, null, 2)}
+    </pre>
   );
 }

--- a/src/app/(main)/helldivers-2/news/war-news/NewsTicker.tsx
+++ b/src/app/(main)/helldivers-2/news/war-news/NewsTicker.tsx
@@ -106,42 +106,9 @@ export default function NewsTicker() {
   if (isLoading) return <div>Loading war news…</div>;
   if (error) return <div>Couldn’t load war news.</div>;
 
-  const items: ApiNewsItem[] = Array.isArray(data?.news) ? data!.news! : [];
-  const uiItems = items.map(normalize).sort((a, b) => b.date.getTime() - a.date.getTime());
-  const top = uiItems.slice(0, 10);
-
-  if (!top.length) return <div>No war news available.</div>;
-
   return (
-    <div className={styles.section}>
-      <h3 className={styles.sectionTitle}>War News</h3>
-      <ul className={styles.styledList} style={{ paddingLeft: 18 }}>
-        {top.map((n) => (
-          <li key={n.id} className={styles.listItem}>
-            <div style={{ fontWeight: 700, lineHeight: 1.25 }}>
-              {n.url ? (
-                <a href={n.url} target="_blank" rel="noreferrer">
-                  {n.title}
-                </a>
-              ) : (
-                n.title
-              )}
-            </div>
-
-            {n.meta && (
-              <div className={styles.paragraph} style={{ opacity: 0.9 }}>
-                {n.meta}
-              </div>
-            )}
-
-            {n.message && <div className={styles.paragraph}>{n.message}</div>}
-
-            <div className={styles.paragraph} style={{ marginBottom: 0 }}>
-              {formatDateTime(n.date)}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+      {JSON.stringify(data ?? null, null, 2)}
+    </pre>
   );
 }

--- a/src/app/api/war/info/route.ts
+++ b/src/app/api/war/info/route.ts
@@ -2,9 +2,9 @@
 import { NextResponse } from 'next/server';
 
 export const runtime = 'edge';            // optional: faster cold starts
-export const revalidate = 86400;          // 24h (default for this route)
+export const revalidate = 60;             // 60s for fresher data during dev
 
-const MAX_AGE = 60 * 60 * 24;             // 24h
+const MAX_AGE = 60;                       // 60s CDN cache
 const UPSTREAM = 'https://helldiverstrainingmanual.com/api/v1/war/info';
 const UA = 'GPT-Fleet-CommunitySite/1.0';
 
@@ -75,7 +75,7 @@ export async function GET() {
         };
 
   const headers = {
-    // CDN caching (Vercel/any proxy): 24h max-age, allow stale while revalidating
+    // Shorter CDN caching for freshness while you validate
     'Cache-Control': `s-maxage=${MAX_AGE}, stale-while-revalidate=${MAX_AGE}`,
     'Content-Type': 'application/json; charset=utf-8',
   };


### PR DESCRIPTION
Display raw JSON on Intel pages and reduce `/api/war/info` cache TTL to debug stale data.

The Intel pages were updated to render raw JSON from their respective APIs (War News, Major Orders, Super Store, Galactic Map) to help diagnose issues with "old information" being displayed. Additionally, the cache revalidation and CDN `s-maxage` for `/api/war/info` were reduced to 60 seconds to ensure fresher data during debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-0357a059-3a16-45f9-8dd6-4a8dd3bccc61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0357a059-3a16-45f9-8dd6-4a8dd3bccc61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

