### PR TITLE
Analyze heroku request logs

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -5,6 +5,12 @@ export const onRequestError = Sentry.captureRequestError;
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('./sentry.server.config');
+    // Opportunistically warm Mongo connection pool on boot without failing startup
+    try {
+      const { default: dbConnect } = await import('@/lib/dbConnect');
+      // Fire and forget warmup; do not block boot
+      dbConnect().catch(() => {});
+    } catch {}
   }
   if (process.env.NEXT_RUNTIME === 'edge') {
     await import('./sentry.edge.config');

--- a/src/lib/dbConnect.ts
+++ b/src/lib/dbConnect.ts
@@ -43,6 +43,14 @@ async function dbConnect(): Promise<Mongoose> {
       bufferCommands: false,
       // Use MONGODB_DB if provided; otherwise defer to DB in the URI
       ...(process.env.MONGODB_DB ? { dbName: process.env.MONGODB_DB } : {}),
+      // Connection tuning for Heroku/dyno environments
+      maxPoolSize: Number(process.env.MONGODB_MAX_POOL_SIZE || 10),
+      minPoolSize: Number(process.env.MONGODB_MIN_POOL_SIZE || 1),
+      serverSelectionTimeoutMS: Number(process.env.MONGODB_SERVER_SELECTION_TIMEOUT_MS || 5000),
+      socketTimeoutMS: Number(process.env.MONGODB_SOCKET_TIMEOUT_MS || 20000),
+      waitQueueTimeoutMS: Number(process.env.MONGODB_WAIT_QUEUE_TIMEOUT_MS || 2000),
+      heartbeatFrequencyMS: Number(process.env.MONGODB_HEARTBEAT_FREQUENCY_MS || 10000),
+      family: 4,
     };
     cached.promise = mongoose
       .connect(MONGODB_URI, opts)


### PR DESCRIPTION
Tune MongoDB connection, warm the DB pool on boot, and add timing logs to `/api/war-news` to improve performance and visibility.

The original logs indicated high database connection times for `/api/users/me` and significant service time for `/api/war-news`. These changes configure a more robust MongoDB connection pool, pre-establish connections on boot, and add detailed timing logs for external API calls in `/api/war-news` to reduce latency and provide better performance insights.

---
<a href="https://cursor.com/background-agent?bcId=bc-e99ce8cb-4eb4-4001-b9e8-84579075b2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e99ce8cb-4eb4-4001-b9e8-84579075b2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

