### PR TITLE
Fix heroku.yml worker image issue

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -3,4 +3,7 @@ build:
     web: Dockerfile
 run:
   web: pnpm start
-  worker: pnpm run scheduler
+  worker:
+    command:
+      - pnpm run scheduler
+    image: web


### PR DESCRIPTION
Add `image` and structured `command` to `run.worker` in `heroku.yml` to resolve Heroku parsing error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e790fc05-fa88-45fa-8c77-3510191fcea7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e790fc05-fa88-45fa-8c77-3510191fcea7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

