### PR TITLE
Update helldivers 2 api data

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -15,11 +15,11 @@ export const revalidate = 300;
  */
 export async function GET() {
   try {
-    // Prefer HellHub aggregated news; fallback to Arrowhead NewsFeed
+    // Prefer Arrowhead NewsFeed for freshness; fallback to HellHub aggregated news
     let items: any[] = [];
-    const hh = await HellHubApi.getNews();
-    if (hh.ok && hh.data) {
-      const raw = hh.data as any;
+    const ah = await ArrowheadApi.getNewsFeed(null);
+    if (ah.ok && ah.data) {
+      const raw = ah.data as any;
       items = Array.isArray(raw?.news)
         ? raw.news
         : Array.isArray(raw?.data)
@@ -29,9 +29,9 @@ export async function GET() {
         : [];
     }
     if (!items.length) {
-      const ah = await ArrowheadApi.getNewsFeed(null);
-      if (ah.ok && ah.data) {
-        const raw = ah.data as any;
+      const hh = await HellHubApi.getNews();
+      if (hh.ok && hh.data) {
+        const raw = hh.data as any;
         items = Array.isArray(raw?.news)
           ? raw.news
           : Array.isArray(raw?.data)

--- a/src/app/api/war-news/route.ts
+++ b/src/app/api/war-news/route.ts
@@ -44,34 +44,33 @@ const pickDate = (n: Item) => {
 export async function GET(req: NextRequest) {
   try {
     const startedAt = Date.now();
-    // Prefer HellHub news if available (aggregated)
+    // Prefer Arrowhead NewsFeed for freshness; fallback to HellHub aggregator
     let list: Item[] = [];
     const t0 = Date.now();
-    const hh = await HellHubApi.getNews();
-    const tHellHub = Date.now() - t0;
-    if (hh.ok && hh.data) {
-      const json: any = hh.data;
-      list = Array.isArray(json)
-        ? json
-        : Array.isArray(json?.news)
-        ? json.news
-        : [];
+    const ah = await ArrowheadApi.getNewsFeed(null);
+    const tArrowhead = Date.now() - t0;
+    if (ah.ok && ah.data) {
+      const json: any = ah.data;
+      list = Array.isArray(json) ? json : Array.isArray(json?.news) ? json.news : [];
     }
     if (!list.length) {
-      // Fallback to Arrowhead NewsFeed for current war
       const t1 = Date.now();
-      const ah = await ArrowheadApi.getNewsFeed(null);
-      const tArrowhead = Date.now() - t1;
-      if (ah.ok && ah.data) {
-        const json: any = ah.data;
-        list = Array.isArray(json) ? json : Array.isArray(json?.news) ? json.news : [];
+      const hh = await HellHubApi.getNews();
+      const tHellHub = Date.now() - t1;
+      if (hh.ok && hh.data) {
+        const json: any = hh.data;
+        list = Array.isArray(json)
+          ? json
+          : Array.isArray(json?.news)
+          ? json.news
+          : [];
       }
       logger.info('war-news timings', {
-        timings: { hellHubMs: tHellHub, arrowheadMs: tArrowhead, totalMs: Date.now() - startedAt },
+        timings: { arrowheadMs: tArrowhead, hellHubMs: tHellHub, totalMs: Date.now() - startedAt },
       });
     } else {
       logger.info('war-news timings', {
-        timings: { hellHubMs: tHellHub, totalMs: Date.now() - startedAt },
+        timings: { arrowheadMs: tArrowhead, totalMs: Date.now() - startedAt },
       });
     }
 

--- a/src/app/api/war/info/route.ts
+++ b/src/app/api/war/info/route.ts
@@ -24,20 +24,22 @@ async function fetchUpstream(): Promise<{
   status: number;
   statusText: string;
 }> {
-  // Prefer HellHub planets and war metadata when available
+  // Prefer Arrowhead live Info for freshness
+  const ah = await ArrowheadApi.getWarInfo(null);
+  if (ah.ok && ah.data) {
+    return { ok: true, data: ah.data as any, status: 200, statusText: 'OK' };
+  }
+
+  // Fallback to HellHub aggregator
   try {
     const hh = await HellHubApi.getWar();
     if (hh.ok && hh.data) {
       return { ok: true, data: hh.data as any, status: 200, statusText: 'OK' };
     }
-  } catch {}
-
-  // Fallback to Arrowhead Info
-  const ah = await ArrowheadApi.getWarInfo(null);
-  if (ah.ok && ah.data) {
-    return { ok: true, data: ah.data as any, status: 200, statusText: 'OK' };
+    return { ok: false, data: undefined, status: hh.status, statusText: hh.statusText } as const;
+  } catch {
+    return { ok: false, data: undefined, status: 599, statusText: 'FetchError' } as const;
   }
-  return { ok: false, data: undefined, status: ah.status, statusText: ah.statusText };
 }
 
 export async function GET() {

--- a/src/app/api/war/major-orders/route.ts
+++ b/src/app/api/war/major-orders/route.ts
@@ -58,17 +58,17 @@ function normalize(raw: RawOrder, i: number): MajorOrder {
 }
 
 async function fetchUpstream() {
-  // Prefer HellHub assignments/major orders if available
-  const hh = await HellHubApi.getAssignments();
-  if (hh.ok && hh.data) {
-    return { ok: true, status: 200, statusText: 'OK', data: hh.data } as const;
-  }
-  // Fallback to Arrowhead assignments by war
+  // Prefer Arrowhead assignments by war for freshness
   const ah = await ArrowheadApi.getAssignments(null);
   if (ah.ok && ah.data) {
     return { ok: true, status: 200, statusText: 'OK', data: ah.data } as const;
   }
-  return { ok: false, status: ah.status, statusText: ah.statusText, data: null as any } as const;
+  // Fallback to HellHub assignments/major orders if available
+  const hh = await HellHubApi.getAssignments();
+  if (hh.ok && hh.data) {
+    return { ok: true, status: 200, statusText: 'OK', data: hh.data } as const;
+  }
+  return { ok: false, status: hh.status, statusText: hh.statusText, data: null as any } as const;
 }
 
 export async function GET() {


### PR DESCRIPTION
Prioritize Arrowhead's live API over HellHub for Helldivers 2 intel routes to ensure fresher data.

The previous configuration preferred HellHub (a community mirror), which could lead to stale data on intel pages. This change switches the primary data source to Arrowhead's live API for `/api/news`, `/api/war-news`, `/api/war/info`, `/api/war/major-orders`, and `/api/war/status`, with HellHub now serving as a fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bcdd456-4352-44f8-955c-056b68a160bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bcdd456-4352-44f8-955c-056b68a160bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

