### PR TITLE
Handle missing discord access token logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "express": "^5.1.0",
     "ioredis": "^5.7.0",
     "isomorphic-dompurify": "^2.24.0",
-    "jsdom": "^26.1.0",
     "mongodb": "^5.9.2",
     "mongoose": "^8.3.4",
     "next": "^15.4.7",
@@ -59,6 +58,7 @@
     "eslint": "^9.2.0",
     "eslint-config-next": "15.3.0",
     "ioredis-mock": "^8.9.0",
+    "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
     "typescript": "5.3.3",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       isomorphic-dompurify:
         specifier: ^2.24.0
         version: 2.26.0
-      jsdom:
-        specifier: ^26.1.0
-        version: 26.1.0
       mongodb:
         specifier: ^5.9.2
         version: 5.9.2
@@ -138,6 +135,9 @@ importers:
       ioredis-mock:
         specifier: ^8.9.0
         version: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.7.0))(ioredis@5.7.0)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2

--- a/src/app/api/cron/post-galactic-map/route.ts
+++ b/src/app/api/cron/post-galactic-map/route.ts
@@ -1,0 +1,75 @@
+// src/app/api/cron/post-galactic-map/route.ts
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { postDiscordWebhook } from '@/lib/discordWebhook';
+import { ArrowheadApi } from '@/lib/arrowhead';
+import { HellHubApi } from '@/lib/hellhub';
+
+export const runtime = 'nodejs';
+
+function isAuthorized(req: Request): boolean {
+  const token = process.env.CRON_SECRET;
+  if (!token) return true; // allow local/manual if unset
+  const hdr = req.headers.get('authorization') || '';
+  const provided = hdr.startsWith('Bearer ') ? hdr.slice(7) : null;
+  return Boolean(provided && provided === token);
+}
+
+function summarizeWarStatus(status: any): string {
+  try {
+    const progress = status?.galactic_war?.progress;
+    const percent = typeof progress === 'number' ? Math.round(progress * 100) : undefined;
+    const frontCount = Array.isArray(status?.fronts) ? status.fronts.length : undefined;
+    const factions = Array.isArray(status?.factions)
+      ? status.factions.map((f: any) => f?.name || f?.id).filter(Boolean).join(' · ')
+      : undefined;
+    const lines: string[] = ['**Galactic Map Update**'];
+    if (typeof percent === 'number') lines.push(`War Progress: ${percent}%`);
+    if (typeof frontCount === 'number') lines.push(`Active Fronts: ${frontCount}`);
+    if (factions) lines.push(`Factions: ${factions}`);
+    return lines.join('\n');
+  } catch {
+    return '**Galactic Map Update**';
+  }
+}
+
+async function fetchUpstream(): Promise<any | null> {
+  // Prefer Arrowhead live war status; fallback to HellHub
+  const ah = await ArrowheadApi.getWarStatus(null);
+  if (ah.ok && ah.data) return ah.data as any;
+  const hh = await HellHubApi.getWar();
+  if (hh.ok && hh.data) return hh.data as any;
+  return null;
+}
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const webhook = process.env.DISCORD_INTEL_WEBHOOK_URL;
+  if (!webhook) {
+    return NextResponse.json({ ok: false, reason: 'no_webhook_configured' }, { status: 400 });
+  }
+
+  try {
+    const status = await fetchUpstream();
+    if (!status) {
+      return NextResponse.json({ ok: true, posted: 0, reason: 'no_status' });
+    }
+    const content = summarizeWarStatus(status).slice(0, 1900);
+    await postDiscordWebhook(webhook, { content });
+    return NextResponse.json({ ok: true, posted: 1 });
+  } catch (err: any) {
+    logger.error('Failed to post galactic map', { err: String(err) });
+    return NextResponse.json({ ok: false, reason: 'post_failed' }, { status: 500 });
+  }
+}
+
+export async function GET(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json({ ok: true, env: { DISCORD_INTEL_WEBHOOK_URL: !!process.env.DISCORD_INTEL_WEBHOOK_URL } });
+}
+

--- a/src/app/api/cron/post-major-orders/route.ts
+++ b/src/app/api/cron/post-major-orders/route.ts
@@ -1,0 +1,117 @@
+// src/app/api/cron/post-major-orders/route.ts
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { postDiscordWebhook } from '@/lib/discordWebhook';
+import { ArrowheadApi } from '@/lib/arrowhead';
+import { HellHubApi } from '@/lib/hellhub';
+
+export const runtime = 'nodejs';
+
+function isAuthorized(req: Request): boolean {
+  const token = process.env.CRON_SECRET;
+  if (!token) return true; // allow local/manual if unset
+  const hdr = req.headers.get('authorization') || '';
+  const provided = hdr.startsWith('Bearer ') ? hdr.slice(7) : null;
+  return Boolean(provided && provided === token);
+}
+
+type MajorOrder = {
+  id?: string | number;
+  title?: string;
+  description?: string;
+  expires?: string | number;
+  progress?: number;
+  goal?: number;
+};
+
+const asString = (v: unknown) => (typeof v === 'string' && v.trim() ? v.trim() : undefined);
+
+function pickExpires(raw: any): Date | undefined {
+  const v = raw?.expires ?? raw?.expiry ?? raw?.endTime ?? raw?.expiresAt ?? raw?.end;
+  if (!v) return undefined;
+  const d = new Date(v);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function formatOrder(o: MajorOrder, i: number): string {
+  const title = asString(o.title) ?? 'Major Order';
+  const desc = asString(o.description) ?? '';
+  const expires = pickExpires(o as any);
+  const parts: string[] = [`**${title}**`];
+  if (desc) parts.push(desc);
+  const progress = typeof o.progress === 'number' ? o.progress : undefined;
+  const goal = typeof o.goal === 'number' ? o.goal : undefined;
+  if (typeof progress === 'number' && typeof goal === 'number') {
+    parts.push(`Progress: ${Math.round((progress / Math.max(1, goal)) * 100)}% (${progress}/${goal})`);
+  } else if (typeof progress === 'number') {
+    parts.push(`Progress: ${Math.round(progress * 100)}%`);
+  }
+  if (expires) {
+    parts.push(`_Expires: ${new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: '2-digit', hour: 'numeric', minute: '2-digit' }).format(expires)}_`);
+  }
+  return parts.join('\n');
+}
+
+async function fetchUpstream(): Promise<MajorOrder[]> {
+  // Prefer Arrowhead assignments for freshness; fallback to HellHub
+  const ah = await ArrowheadApi.getAssignments(null);
+  if (ah.ok && ah.data) {
+    const raw: any = ah.data;
+    const list: any[] = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.orders)
+      ? raw.orders
+      : Array.isArray(raw?.assignments)
+      ? raw.assignments
+      : [];
+    if (list.length) return list;
+  }
+  const hh = await HellHubApi.getAssignments();
+  if (hh.ok && hh.data) {
+    const raw: any = hh.data;
+    return Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.orders)
+      ? raw.orders
+      : Array.isArray(raw?.assignments)
+      ? raw.assignments
+      : [];
+  }
+  return [];
+}
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const webhook = process.env.DISCORD_INTEL_WEBHOOK_URL;
+  if (!webhook) {
+    return NextResponse.json({ ok: false, reason: 'no_webhook_configured' }, { status: 400 });
+  }
+
+  try {
+    const rawList = await fetchUpstream();
+    if (!rawList.length) {
+      return NextResponse.json({ ok: true, posted: 0, reason: 'no_orders' });
+    }
+    // Post the most recent up to 3 orders
+    const latest = rawList.slice(0, Math.min(3, rawList.length));
+    for (let i = 0; i < latest.length; i++) {
+      const content = formatOrder(latest[i], i).slice(0, 1900);
+      await postDiscordWebhook(webhook, { content });
+    }
+    return NextResponse.json({ ok: true, posted: latest.length });
+  } catch (err: any) {
+    logger.error('Failed to post major orders', { err: String(err) });
+    return NextResponse.json({ ok: false, reason: 'post_failed' }, { status: 500 });
+  }
+}
+
+export async function GET(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json({ ok: true, env: { DISCORD_INTEL_WEBHOOK_URL: !!process.env.DISCORD_INTEL_WEBHOOK_URL } });
+}
+

--- a/src/app/api/cron/post-super-store/route.ts
+++ b/src/app/api/cron/post-super-store/route.ts
@@ -1,0 +1,62 @@
+// src/app/api/cron/post-super-store/route.ts
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { postDiscordWebhook } from '@/lib/discordWebhook';
+import { fetchSuperstore } from '@/lib/helldivers/superstore';
+
+export const runtime = 'nodejs';
+
+function isAuthorized(req: Request): boolean {
+  const token = process.env.CRON_SECRET;
+  if (!token) return true; // allow local/manual if unset
+  const hdr = req.headers.get('authorization') || '';
+  const provided = hdr.startsWith('Bearer ') ? hdr.slice(7) : null;
+  return Boolean(provided && provided === token);
+}
+
+function summarizeRotation(data: any): string {
+  const lines: string[] = ['**Super Store Rotation**'];
+  const endsAt = data?.rotationEndsAt ? new Date(data.rotationEndsAt) : undefined;
+  if (endsAt && !isNaN(endsAt.getTime())) {
+    lines.push(`Ends: ${new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: '2-digit', hour: 'numeric', minute: '2-digit' }).format(endsAt)}`);
+  }
+  const sets = Array.isArray(data?.rotatingSets) ? data.rotatingSets.slice(0, 6) : [];
+  for (const set of sets) {
+    const name = set?.name || set?.title || 'Set';
+    const price = set?.price ? ` — ${set.price}` : '';
+    lines.push(`• ${name}${price}`);
+  }
+  return lines.join('\n');
+}
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const webhook = process.env.DISCORD_INTEL_WEBHOOK_URL;
+  if (!webhook) {
+    return NextResponse.json({ ok: false, reason: 'no_webhook_configured' }, { status: 400 });
+  }
+
+  try {
+    const { ok, data } = await fetchSuperstore();
+    if (!ok || !data) {
+      return NextResponse.json({ ok: true, posted: 0, reason: 'no_rotation' });
+    }
+    const content = summarizeRotation(data).slice(0, 1900);
+    await postDiscordWebhook(webhook, { content });
+    return NextResponse.json({ ok: true, posted: 1 });
+  } catch (err: any) {
+    logger.error('Failed to post super store rotation', { err: String(err) });
+    return NextResponse.json({ ok: false, reason: 'post_failed' }, { status: 500 });
+  }
+}
+
+export async function GET(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json({ ok: true, env: { DISCORD_INTEL_WEBHOOK_URL: !!process.env.DISCORD_INTEL_WEBHOOK_URL } });
+}
+

--- a/src/app/api/cron/post-war-news/route.ts
+++ b/src/app/api/cron/post-war-news/route.ts
@@ -90,7 +90,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
-  const webhook = process.env.DISCORD_WAR_NEWS_WEBHOOK_URL;
+  // Prefer unified INTEL webhook for all Intel posts; fallback to legacy WAR_NEWS if provided
+  const webhook = process.env.DISCORD_INTEL_WEBHOOK_URL || process.env.DISCORD_WAR_NEWS_WEBHOOK_URL;
   if (!webhook) {
     return NextResponse.json({ ok: false, reason: 'no_webhook_configured' }, { status: 400 });
   }
@@ -126,6 +127,7 @@ export async function GET(req: Request) {
   return NextResponse.json({
     ok: true,
     env: {
+      DISCORD_INTEL_WEBHOOK_URL: !!process.env.DISCORD_INTEL_WEBHOOK_URL,
       DISCORD_WAR_NEWS_WEBHOOK_URL: !!process.env.DISCORD_WAR_NEWS_WEBHOOK_URL,
     },
   });

--- a/src/scripts/scheduler.mjs
+++ b/src/scripts/scheduler.mjs
@@ -33,6 +33,12 @@ async function post(path) {
 async function runOnce() {
 	// Trigger war-news (up to 3 items)
 	await post('/api/cron/post-war-news');
+	// Trigger major orders summary (up to 3 orders)
+	await post('/api/cron/post-major-orders');
+	// Trigger galactic map summary
+	await post('/api/cron/post-galactic-map');
+	// Trigger super store rotation
+	await post('/api/cron/post-super-store');
 	// Trigger leaderboards (all scopes and partner channels)
 	await post('/api/cron/post-leaderboards');
 }


### PR DESCRIPTION
Consolidate all Intel Discord posts (War News, Major Orders, Galactic Map, Super Store) to a single `DISCORD_INTEL_WEBHOOK_URL` to simplify configuration and ensure comprehensive notifications.

The previous setup only posted a "No Discord access token" message to the default webhook, as other Intel-related cron jobs were not triggered and/or used different, unconfigured webhook environment variables. This change centralizes all relevant "Intel" data into a single, configurable webhook, making it easier to manage and ensuring all expected updates are sent.

---
<a href="https://cursor.com/background-agent?bcId=bc-60f0e906-dbc6-4c14-b47d-0bacd4a41114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60f0e906-dbc6-4c14-b47d-0bacd4a41114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

