### PR TITLE
Log and process api requests

### DIFF
--- a/src/app/(main)/profile/me/page.tsx
+++ b/src/app/(main)/profile/me/page.tsx
@@ -72,7 +72,7 @@ export default function ProfilePage() {
       (async () => {
         setLoading(true);
         const [resMe, resLast] = await Promise.all([
-          fetch('/api/users/me'),
+          fetch('/api/users/me?include=avatar,submissions'),
           fetch('/api/users/profile/last'),
         ]);
         const data = await resMe.json();

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -72,7 +72,7 @@ export default function ProfilePage() {
       (async () => {
         setLoading(true);
         const [resMe, resLast] = await Promise.all([
-          fetch('/api/users/me'),
+          fetch('/api/users/me?include=avatar,submissions'),
           fetch('/api/users/profile/last'),
         ]);
         const data = await resMe.json();

--- a/src/app/api/twitch/creators/route.ts
+++ b/src/app/api/twitch/creators/route.ts
@@ -1,19 +1,50 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { fetchTwitchCreators } from '@/lib/twitch';
+import { jsonWithETag } from '@/lib/httpCache';
 
-export async function GET() {
-  const creatorsData = await fetchTwitchCreators();
-  if (!creatorsData) {
-    return NextResponse.json(
-      { error: 'Failed to fetch data from Twitch.' },
-      { status: 500 }
-    );
+type CacheEntry = { data: any; expiresAt: number };
+const globalForCache = globalThis as unknown as { __twitch_creators_cache__?: CacheEntry };
+const TTL_MS = 10 * 60_000; // 10 minutes
+
+function getCached(): CacheEntry | null {
+  try {
+    const c = globalForCache.__twitch_creators_cache__;
+    if (c && c.expiresAt > Date.now()) return c;
+    return null;
+  } catch { return null; }
+}
+
+function setCached(data: any) {
+  try {
+    globalForCache.__twitch_creators_cache__ = { data, expiresAt: Date.now() + TTL_MS };
+  } catch {}
+}
+
+export async function GET(req: NextRequest) {
+  const cached = getCached();
+  if (cached) {
+    return jsonWithETag(req, cached.data, {
+      headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=600' },
+    });
   }
 
-  const response = NextResponse.json(creatorsData);
-  response.headers.set(
-    'Cache-Control',
-    'public, s-maxage=60, stale-while-revalidate=120'
-  ); // Cache for 60s, allow stale for 120s
-  return response;
+  // Soft timeout wrapper
+  const withTimeout = async <T,>(p: Promise<T>, ms = 5000): Promise<T | null> => {
+    let timer: any;
+    return await Promise.race([
+      p.finally(() => clearTimeout(timer)),
+      new Promise<T | null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+      }),
+    ]);
+  };
+
+  const creatorsData = await withTimeout(fetchTwitchCreators());
+  if (creatorsData) setCached(creatorsData);
+
+  // Serve last-good on failure
+  const data = creatorsData ?? getCached()?.data ?? [];
+  return jsonWithETag(req, data, {
+    headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=600' },
+  });
 }

--- a/src/app/components/forum/ProfileEditForm.tsx
+++ b/src/app/components/forum/ProfileEditForm.tsx
@@ -96,7 +96,7 @@ export default function ProfileEditForm() {
     (async () => {
       try {
         setLoading(true);
-        const res = await fetch('/api/users/me', { signal: ac.signal });
+        const res = await fetch('/api/users/me?include=avatar', { signal: ac.signal });
         if (!res.ok) throw new Error(`Failed to load profile (${res.status})`);
         const data = (await res.json()) as UserMe;
 


### PR DESCRIPTION
Implement ETag and caching for `/api/users/me`, Twitch, and war endpoints, and add Discord webhook deduplication to improve performance and reliability.

The `/api/users/me` endpoint's payload was reduced by making heavy fields (avatar, submissions) opt-in via a query parameter, significantly cutting bandwidth. ETag and `Cache-Control` headers were added to `/api/users/me`, `/api/twitch/creators`, `/api/war/info`, and `/api/war/status` to enable conditional requests and client-side caching. In-memory caching was introduced for Twitch and Discord API calls to reduce upstream load and improve response times, with timeouts and last-good fallbacks for external integrations. Discord webhook posting now includes deduplication logic to prevent duplicate messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f812cdb-0d54-45ab-b724-71609fa8ed7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f812cdb-0d54-45ab-b724-71609fa8ed7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

