### PR TITLE
Log war news and status updates

### DIFF
--- a/src/app/(main)/helldivers-2/news/war-news/NewsTicker.tsx
+++ b/src/app/(main)/helldivers-2/news/war-news/NewsTicker.tsx
@@ -71,8 +71,9 @@ const parseDateValue = (raw: unknown): Date | null => {
   return null;
 };
 
-const pickDate = (n: ApiNewsItem): Date => {
+const pickDate = (n: ApiNewsItem): Date | null => {
   const candidates: Array<unknown> = [
+    (n as any).date,
     (n as any).published,
     (n as any).timestamp,
     (n as any).updatedAt,
@@ -83,11 +84,11 @@ const pickDate = (n: ApiNewsItem): Date => {
     const d = parseDateValue(c);
     if (d) return d;
   }
-  return new Date();
+  return null;
 };
 
 const normalize = (n: ApiNewsItem): UINews => {
-  const date = pickDate(n);
+  const date = pickDate(n) ?? new Date(0);
   const title =
     asString(n.title) ??
     asString((n as any).headline) ??

--- a/src/app/api/war-news/route.ts
+++ b/src/app/api/war-news/route.ts
@@ -80,7 +80,7 @@ const pickDate = (n: Item) => {
     const d = parseDateValue(c);
     if (d) return d;
   }
-  return new Date();
+  return null;
 };
 
 export async function GET(req: NextRequest) {
@@ -131,6 +131,7 @@ export async function GET(req: NextRequest) {
     // Normalize and sort newest-first by computed date
     const newsAll = list
       .map((n, i) => ({ raw: n, index: i, date: pickDate(n) }))
+      .filter((x) => x.date instanceof Date && !isNaN(x.date.getTime()))
       .sort((a, b) => b.date.getTime() - a.date.getTime())
       .map(({ raw: n, index: i, date }) => {
         const title =
@@ -160,6 +161,7 @@ export async function GET(req: NextRequest) {
           title,
           message,
           date: date.toISOString(),
+          published: date.toISOString(),
           url,
           planet: asString((n as any).planet),
           sector: asString((n as any).sector ?? (n as any).theater),
@@ -173,7 +175,7 @@ export async function GET(req: NextRequest) {
     // Filter to last 24 hours for freshness
     const now = Date.now();
     const news = newsAll.filter((item) => {
-      const t = new Date(item.date as any).getTime();
+      const t = new Date((item as any).published || (item as any).date).getTime();
       return Number.isFinite(t) && now - t <= TWENTY_FOUR_HOURS_MS;
     });
 


### PR DESCRIPTION
Fix stale news content by ensuring correct date parsing and filtering in both the API and client.

The previous implementation defaulted missing date fields to the current time, causing news items to be incorrectly sorted and filtered as fresh when they were actually old. This PR introduces a `published` field in the API, prioritizes explicit date fields, and ensures that both the API and client strictly use valid upstream timestamps for freshness checks and display.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf89b85e-ecfc-4cce-b240-540d6b4b3636">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf89b85e-ecfc-4cce-b240-540d6b4b3636">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

