### PR TITLE
Build and lint application code

### DIFF
--- a/src/app/api/war-news/route.ts
+++ b/src/app/api/war-news/route.ts
@@ -83,6 +83,10 @@ const pickDate = (n: Item) => {
   return null;
 };
 
+// Type guard that narrows to objects with a non-NaN Date in the `date` field
+const hasValidDate = <T extends { date: Date | null }>(x: T): x is T & { date: Date } =>
+  x.date instanceof Date && !isNaN(x.date.getTime());
+
 export async function GET(req: NextRequest) {
   try {
     const startedAt = Date.now();
@@ -131,7 +135,7 @@ export async function GET(req: NextRequest) {
     // Normalize and sort newest-first by computed date
     const newsAll = list
       .map((n, i) => ({ raw: n, index: i, date: pickDate(n) }))
-      .filter((x) => x.date instanceof Date && !isNaN(x.date.getTime()))
+      .filter(hasValidDate)
       .sort((a, b) => b.date.getTime() - a.date.getTime())
       .map(({ raw: n, index: i, date }) => {
         const title =


### PR DESCRIPTION
Resolve TypeScript build error in `war-news` API by adding a type guard for date sorting.

The previous filter `(x) => x.date instanceof Date && !isNaN(x.date.getTime())` was not sufficient for TypeScript to narrow the type of `x.date` to `Date` within the subsequent `sort` callback, leading to a `Type error: 'b.date' is possibly 'null'.` The new `hasValidDate` type guard explicitly ensures the type is `Date` before sorting.

---
<a href="https://cursor.com/background-agent?bcId=bc-df0a33ce-a0ae-4ac7-876c-e4f4a3a71a5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df0a33ce-a0ae-4ac7-876c-e4f4a3a71a5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

