### PR TITLE
Update unavailable thumbnails and autoplay recent video

### DIFF
--- a/src/app/(main)/helldivers-2/creators/page.tsx
+++ b/src/app/(main)/helldivers-2/creators/page.tsx
@@ -322,12 +322,13 @@ export default function CreatorsPage() {
                   <iframe
                     width="100%"
                     height="100%"
-                    src={`https://www.youtube.com/embed/live_stream?channel=${creator.channelId}&autoplay=1&mute=1`}
-                    title={`${creator.name}'s Live Stream`}
+                    src={`https://www.youtube.com/embed/videoseries?list=${`UU${creator.channelId.slice(2)}`}&autoplay=1&mute=1&rel=0&modestbranding=1&playsinline=1`}
+                    title={`${creator.name} Latest Uploads`}
                     frameBorder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowFullScreen
                     className={styles.twitchEmbed}
+                    referrerPolicy="strict-origin-when-cross-origin"
                   ></iframe>
                 </div>
                 <div className={styles.infoSection}>

--- a/src/app/(main)/helldivers-2/page.tsx
+++ b/src/app/(main)/helldivers-2/page.tsx
@@ -19,6 +19,7 @@ export default function HelldiversPage() {
   const tiktokUrl = process.env.NEXT_PUBLIC_SOCIAL_TIKTOK_URL;
 
   const helldiversChannelId = 'UCkH5t4g_7-tA4n5-d-lVd-g';
+  const uploadsPlaylistId = `UU${helldiversChannelId.slice(2)}`;
 
   return (
     <div className={styles.wrapper}>
@@ -30,11 +31,12 @@ export default function HelldiversPage() {
             <iframe
               width="100%"
               height="100%"
-              src={`https://www.youtube.com/embed/live_stream?channel=${helldiversChannelId}&autoplay=1&mute=1`}
+              src={`https://www.youtube.com/embed/videoseries?list=${uploadsPlaylistId}&autoplay=1&mute=1&rel=0&modestbranding=1&playsinline=1`}
               title="Helldivers 2 Live Stream"
               frameBorder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowFullScreen
+              referrerPolicy="strict-origin-when-cross-origin"
             ></iframe>
           </div>
         </section>


### PR DESCRIPTION
Fix "This video is unavailable" thumbnails and autoplay the most recent video by switching YouTube embeds to use the uploads playlist.

The `live_stream` embed type only displays content when a channel is actively live, leading to "This video is unavailable" errors when no live stream is active. By switching to the `videoseries` embed type with the channel's uploads playlist, the most recent uploaded video will always be displayed, ensuring content availability and enabling consistent autoplay functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dbaff6e-9f09-4156-89d0-5f9a08251a05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5dbaff6e-9f09-4156-89d0-5f9a08251a05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

