### PR TITLE
Fix youtube video aspect ratio on homepage

### DIFF
--- a/src/app/(main)/helldivers-2/HelldiversBase.module.css
+++ b/src/app/(main)/helldivers-2/HelldiversBase.module.css
@@ -155,3 +155,46 @@
 }
 
 /* (Reduced motion styles moved to globals.css) */
+
+/* ---------- YouTube Embeds ---------- */
+/* Single embed container with 16:9 ratio */
+.youtubeEmbed {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  background-color: #000;
+  border: 1px solid var(--color-border);
+}
+.youtubeEmbed iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+/* Carousel styles (for potential YouTubeCarousel usage on this page) */
+.youtubeCarouselContainer {
+  margin: 2rem auto 3rem;
+  max-width: 1024px;
+  padding-top: 2rem;
+}
+.youtubeSlide {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background);
+}
+.youtubeIframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -79,9 +79,9 @@ export function middleware(req: NextRequest) {
       "frame-ancestors 'self'",
 
       // Allow embeds from Twitch, YouTube, and Google
-      "frame-src 'self' https://accounts.google.com https://player.twitch.tv https://www.youtube.com",
+      "frame-src 'self' https://accounts.google.com https://player.twitch.tv https://www.youtube.com https://www.youtube-nocookie.com https://*.youtube.com",
       // (Safari fallback)
-      "child-src 'self' https://accounts.google.com",
+      "child-src 'self' https://accounts.google.com https://player.twitch.tv https://www.youtube.com https://www.youtube-nocookie.com https://*.youtube.com",
 
       // Allow scripts from Google
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com",


### PR DESCRIPTION
Fix YouTube video unavailability and incorrect aspect ratio on the Helldivers page by updating CSP and adding 16:9 embed styles.

The Content Security Policy was too restrictive, only allowing `www.youtube.com`, which blocked embeds from `youtube-nocookie.com` and other subdomains. Additionally, the Helldivers page's YouTube iframe lacked proper aspect ratio styling, leading to distorted video dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-302f86e3-1f56-4c87-a698-eddd8ce347be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-302f86e3-1f56-4c87-a698-eddd8ce347be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

