### PR TITLE
Move review carousel to homepage bottom

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,8 @@ import 'swiper/css/effect-coverflow';
 
 // Import the GameCard component
 import GameCard from '@/app/components/common/GameCard'; // Adjust path if needed
+import ReviewsRotator from '@/app/(main)/helldivers-2/ReviewsRotator';
+import { reviews as helldiversReviews } from '@/app/(main)/helldivers-2/reviews';
 
 // --- Define Type for Game Division Data ---
 interface GameDivision {
@@ -260,6 +262,7 @@ export default function Home() {
             </Swiper>
           </SwiperWrapper>
         </CarouselSection>
+        <ReviewsRotator reviews={helldiversReviews} />
       </Container>
     );
   }


### PR DESCRIPTION
Add the review carousel to the bottom of the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-efda3441-ec09-49ef-a3dd-24391f124d27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-efda3441-ec09-49ef-a3dd-24391f124d27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

