### PR TITLE
Add solo and squad leaderboard tabs

### DIFF
--- a/src/app/(main)/helldivers-2/LeaderboardServer.tsx
+++ b/src/app/(main)/helldivers-2/LeaderboardServer.tsx
@@ -15,7 +15,7 @@ async function fetchLeaderboard() {
     process.env.NEXT_PUBLIC_SITE_HOST;
   const base = `${proto}://${host}`;
   const res = await fetch(
-    `${base}/api/helldivers/leaderboard/overview?sortBy=Kills&sortDir=desc&limit=100`,
+    `${base}/api/helldivers/leaderboard/batch?scopes=day,week,month,lifetime,solo,squad&sortBy=Kills&sortDir=desc&limit=100`,
     { cache: 'no-store' }
   );
   if (!res.ok) {

--- a/src/app/api/helldivers/leaderboard/route.ts
+++ b/src/app/api/helldivers/leaderboard/route.ts
@@ -35,11 +35,13 @@ export async function GET(req: NextRequest) {
         ? 'lifetime'
         : scopeParam === 'solo'
           ? 'solo'
-          : scopeParam === 'week'
-            ? 'week'
-            : scopeParam === 'day'
-              ? 'day'
-              : 'month';
+          : scopeParam === 'squad'
+            ? 'squad'
+            : scopeParam === 'week'
+              ? 'week'
+              : scopeParam === 'day'
+                ? 'day'
+                : 'month';
     const month = monthParam ? parseInt(monthParam, 10) : undefined;
     const year = yearParam ? parseInt(yearParam, 10) : undefined;
 

--- a/src/app/components/leaderboard/HelldiversLeaderboard.tsx
+++ b/src/app/components/leaderboard/HelldiversLeaderboard.tsx
@@ -52,6 +52,8 @@ interface LeaderboardPayload {
   week?: { results: LeaderboardRow[]; error?: number };
   month?: { results: LeaderboardRow[]; error?: number };
   lifetime?: { results: LeaderboardRow[]; error?: number };
+  solo?: { results: LeaderboardRow[]; error?: number };
+  squad?: { results: LeaderboardRow[]; error?: number };
 }
 
 const sortFieldMap: Record<SortField, keyof LeaderboardRow> = {
@@ -392,6 +394,14 @@ export default function HelldiversLeaderboard({
     () => sortRows(initialData.lifetime?.results || [], sortBy, sortDir),
     [initialData, sortBy, sortDir]
   );
+  const soloData = useMemo(
+    () => sortRows(initialData.solo?.results || [], sortBy, sortDir),
+    [initialData, sortBy, sortDir]
+  );
+  const squadData = useMemo(
+    () => sortRows(initialData.squad?.results || [], sortBy, sortDir),
+    [initialData, sortBy, sortDir]
+  );
 
   const monthError = initialData.month?.error
     ? `Request failed: ${initialData.month.error}`
@@ -405,6 +415,12 @@ export default function HelldiversLeaderboard({
   const yearlyError = initialData.lifetime?.error
     ? `Request failed: ${initialData.lifetime.error}`
     : null;
+  const soloError = initialData.solo?.error
+    ? `Request failed: ${initialData.solo.error}`
+    : null;
+  const squadError = initialData.squad?.error
+    ? `Request failed: ${initialData.squad.error}`
+    : null;
 
   const isLoading = false;
 
@@ -412,6 +428,8 @@ export default function HelldiversLeaderboard({
   const [yearlyTotalsSearch, setYearlyTotalsSearch] = useState<string>('');
   const [weekSearch, setWeekSearch] = useState<string>('');
   const [daySearch, setDaySearch] = useState<string>('');
+  const [soloSearch, setSoloSearch] = useState<string>('');
+  const [squadSearch, setSquadSearch] = useState<string>('');
 
   const toggleSort = (field: SortField) => {
     if (field === sortBy) {
@@ -427,7 +445,7 @@ export default function HelldiversLeaderboard({
   const activeSort = { sortBy, sortDir };
 
   const [activeTab, setActiveTab] = useState<
-    'daily' | 'weekly' | 'monthly' | 'yearly'
+    'daily' | 'weekly' | 'monthly' | 'yearly' | 'solo' | 'squad'
   >('daily');
 
   useEffect(() => {
@@ -437,7 +455,9 @@ export default function HelldiversLeaderboard({
         hash === 'daily' ||
         hash === 'weekly' ||
         hash === 'monthly' ||
-        hash === 'yearly'
+        hash === 'yearly' ||
+        hash === 'solo' ||
+        hash === 'squad'
       ) {
         setActiveTab(hash as typeof activeTab);
       }
@@ -458,6 +478,8 @@ export default function HelldiversLeaderboard({
   const monthTitle = `Monthly Leaderboard - ${now.toLocaleString('default', { month: 'long' })} ${now.getUTCFullYear()}`;
   const dayTitle = `Daily Leaderboard - ${now.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}`;
   const weekTitle = `Weekly Leaderboard - Week ${getWeekNumber(now)} of ${now.getUTCFullYear()}`;
+  const soloTitle = 'Solo Leaderboard';
+  const squadTitle = 'Squad Leaderboard';
 
   return (
     <div>
@@ -489,6 +511,20 @@ export default function HelldiversLeaderboard({
           aria-pressed={activeTab === 'yearly'}
         >
           Yearly
+        </button>
+        <button
+          className="btn btn-secondary"
+          onClick={() => setActiveTab('solo')}
+          aria-pressed={activeTab === 'solo'}
+        >
+          Solo
+        </button>
+        <button
+          className="btn btn-secondary"
+          onClick={() => setActiveTab('squad')}
+          aria-pressed={activeTab === 'squad'}
+        >
+          Squad
         </button>
       </div>
 
@@ -553,6 +589,38 @@ export default function HelldiversLeaderboard({
           searchTerm={yearlyTotalsSearch}
           onSearch={setYearlyTotalsSearch}
           sectionId="yearly"
+        />
+      )}
+
+      {activeTab === 'solo' && (
+        <LeaderboardTableSection
+          title={soloTitle}
+          rows={soloData}
+          loading={isLoading}
+          error={soloError}
+          activeSort={activeSort}
+          onSort={toggleSort}
+          showAverages={false}
+          showTotals={true}
+          searchTerm={soloSearch}
+          onSearch={setSoloSearch}
+          sectionId="solo"
+        />
+      )}
+
+      {activeTab === 'squad' && (
+        <LeaderboardTableSection
+          title={squadTitle}
+          rows={squadData}
+          loading={isLoading}
+          error={squadError}
+          activeSort={activeSort}
+          onSort={toggleSort}
+          showAverages={false}
+          showTotals={true}
+          searchTerm={squadSearch}
+          onSearch={setSquadSearch}
+          sectionId="squad"
         />
       )}
     </div>

--- a/src/lib/helldiversLeaderboard.ts
+++ b/src/lib/helldiversLeaderboard.ts
@@ -18,7 +18,7 @@ export const VALID_SORT_FIELDS = [
 
 export type SortField = (typeof VALID_SORT_FIELDS)[number];
 export type SortDir = 'asc' | 'desc';
-export type LeaderboardScope = 'month' | 'week' | 'day' | 'lifetime' | 'solo';
+export type LeaderboardScope = 'month' | 'week' | 'day' | 'lifetime' | 'solo' | 'squad';
 
 export interface HelldiversLeaderboardRow {
   rank: number;
@@ -77,11 +77,13 @@ export async function fetchHelldiversLeaderboard(options?: {
       ? 'lifetime'
       : options?.scope === 'solo'
         ? 'solo'
-        : options?.scope === 'week'
-          ? 'week'
-          : options?.scope === 'day'
-            ? 'day'
-            : 'month';
+        : options?.scope === 'squad'
+          ? 'squad'
+          : options?.scope === 'week'
+            ? 'week'
+            : options?.scope === 'day'
+              ? 'day'
+              : 'month';
 
   const client = await getMongoClientPromise();
   const db = client.db(getDbName());
@@ -542,7 +544,9 @@ export async function fetchHelldiversLeaderboard(options?: {
       ? 'Lifetime_Stats'
       : scope === 'solo'
         ? 'Solo_Stats'
-        : 'User_Stats';
+        : scope === 'squad'
+          ? 'Squad_Stats'
+          : 'User_Stats';
   const cursor = db
     .collection(collectionName)
     .aggregate(pipeline, { allowDiskUse: true });


### PR DESCRIPTION
Add Solo and Squad leaderboard tabs to the Leaderboard page with corresponding backend support.

---
<a href="https://cursor.com/background-agent?bcId=bc-2514292d-9bbe-4e29-ab65-53db12d0db69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2514292d-9bbe-4e29-ab65-53db12d0db69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

