### PR TITLE
Fix CSS module handling and enforce case-sensitive imports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+dist
+.git
+*.log

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { FlatCompat } from '@eslint/eslintrc';
+import importPlugin from 'eslint-plugin-import';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,12 +13,32 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
+    plugins: {
+      import: importPlugin,
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx', '.d.ts'],
+        },
+      },
+    },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'react/no-unescaped-entities': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       'prefer-const': 'off',
+      'import/no-unresolved': [
+        'error',
+        {
+          caseSensitive: true,
+          ignore: ['\\.module\\.css$'],
+        },
+      ],
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^9.2.0",
     "eslint-config-next": "15.3.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
     "ioredis-mock": "^8.9.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,12 @@ importers:
       eslint-config-next:
         specifier: 15.3.0
         version: 15.3.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.3.3)
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.5.1))
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.3.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.5.1))
       ioredis-mock:
         specifier: ^8.9.0
         version: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.7.0))(ioredis@5.7.0)

--- a/src/app/(main)/helldivers-2/academy/apply/page.tsx
+++ b/src/app/(main)/helldivers-2/academy/apply/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import base from '../../HelldiversBase.module.css';
+import base from '../../styles/HelldiversBase.module.css';
 import styles from './Apply.module.css';
 import Quiz, { type Question } from '../../../../../components/academy/training/Quiz'; // adjust path if needed
 

--- a/src/app/(main)/helldivers-2/academy/page.tsx
+++ b/src/app/(main)/helldivers-2/academy/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import base from '../HelldiversBase.module.css';
+import base from '../styles/HelldiversBase.module.css';
 import page from './AcademyPage.module.css';
 import ModuleCard from '@/components/academy/ModuleCard';
 import { MODULES, type ModuleWithDetails } from '@/components/academy/Modules';

--- a/src/app/(main)/helldivers-2/academy/training/page.tsx
+++ b/src/app/(main)/helldivers-2/academy/training/page.tsx
@@ -2,7 +2,7 @@ import styles from './TrainingPage.module.css';
 import Quiz, { type Question } from '../../../../../components/academy/training/Quiz';
 import hd2Questions from '../../../../../components/academy/training/hd2Questions';
 import hd1Questions from '../../../../../components/academy/training/hd1Questions';
-import base from '../../HelldiversBase.module.css';
+import base from '../../styles/HelldiversBase.module.css';
 
 const chunk = (arr: Question[], size: number) =>
   Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>

--- a/src/app/(main)/helldivers-2/campaigns/page.tsx
+++ b/src/app/(main)/helldivers-2/campaigns/page.tsx
@@ -3,11 +3,11 @@
 
 import React, { useState } from 'react';
 import { FaChevronDown } from 'react-icons/fa';
-import base from '../HelldiversBase.module.css';
-import exp from '../components/Expanders.module.css';
-import code from '@/app/components/CodeBlocks.module.css';
+import base from '../styles/HelldiversBase.module.css';
+import exp from '@/components/common/Expanders.module.css';
+import code from '@/components/common/CodeBlocks.module.css';
 import SubmitCampaignModal from '@/components/campaigns/SubmitCampaignModal';
-import YoutubeCarouselPlaceholder from '../../../../components/campaigns/YoutubeCarouselCampaign';
+import YoutubeCarouselPlaceholder from '@/components/campaigns/YoutubeCarouselCampaign';
 
 interface PrestigeMissionData {
   id: string;

--- a/src/app/(main)/helldivers-2/challenges/page.tsx
+++ b/src/app/(main)/helldivers-2/challenges/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import Expander from '@/components/common/Expander';
-import base from '@/app/(main)/helldivers-2/HelldiversBase.module.css';
-import code from '@/app/components/CodeBlocks.module.css';
+import base from '@/app/(main)/helldivers-2/styles/HelldiversBase.module.css';
+import code from '@/components/common/CodeBlocks.module.css';
 import YoutubeCarouselPlaceholder from '@/components/campaigns/YoutubeCarouselCampaign';
 
 export interface ChallengeLevelData {

--- a/src/app/(main)/helldivers-2/creators/page.tsx
+++ b/src/app/(main)/helldivers-2/creators/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import { FaTwitch, FaCircle } from 'react-icons/fa';
 import styles from './CreatorsPage.module.css'; // Import the CSS Module
 import { logger } from '@/lib/logger';
-import base from '../HelldiversBase.module.css';
+import base from '../styles/HelldiversBase.module.css';
 
 // Define the structure for creator data fetched from *your* API route
 interface CreatorData {

--- a/src/app/(main)/helldivers-2/home/page.tsx
+++ b/src/app/(main)/helldivers-2/home/page.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { FaDiscord, FaYoutube } from 'react-icons/fa';
 import { FaTiktok } from 'react-icons/fa6';
-import styles from './HelldiversBase.module.css';
+import styles from './HelldiversPage.module.css';
 import reviews from '../../../../components/home/reviews';
 
 // Note: do NOT pass { ssr: false } here — it's not allowed in Server Components.

--- a/src/app/(main)/helldivers-2/leaderboard/page.tsx
+++ b/src/app/(main)/helldivers-2/leaderboard/page.tsx
@@ -1,6 +1,6 @@
 // src/app/(main)/helldivers-2/leaderboard/page.tsx
 import LeaderboardServer from '@/components/leaderboard/LeaderboardServer';
-import styles from '../HelldiversBase.module.css';
+import styles from '../styles/HelldiversBase.module.css';
 
 export default function LeaderboardPage() {
   return (

--- a/src/app/(main)/helldivers-2/merch/page.tsx
+++ b/src/app/(main)/helldivers-2/merch/page.tsx
@@ -1,6 +1,6 @@
 // src/app/(main)/helldivers-2/merch/page.tsx
 import Image from 'next/image';
-import NoPrefetchLink from '@/app/components/NoPrefetchLink';
+import NoPrefetchLink from '@/components/common/NoPrefetchLink';
 import React from 'react';
 import styles from './MerchPage.module.css';
 import { logger } from '@/lib/logger';

--- a/src/app/(main)/helldivers-2/profile/me/page.tsx
+++ b/src/app/(main)/helldivers-2/profile/me/page.tsx
@@ -13,8 +13,8 @@ import Link from 'next/link';
 import useSWR from 'swr';
 import { FaTwitch } from 'react-icons/fa';
 
-import base from '../../helldivers-2/HelldiversBase.module.css';
-import s from '@/app/components/forum/ProfileEditForm.module.css'; // reuse Settings layout styles
+import base from '../../styles/HelldiversBase.module.css';
+import s from '@/components/profile/ProfileEditForm.module.css'; // reuse Settings layout styles
 
 const overlayStyle: CSSProperties = {
   position: 'fixed',

--- a/src/app/(main)/helldivers-2/profile/page.tsx
+++ b/src/app/(main)/helldivers-2/profile/page.tsx
@@ -1,10 +1,9 @@
 'use client';
-/* eslint-disable @next/next/no-img-element */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import useSWR from 'swr';
-import baseStyles from '../helldivers-2/HelldiversBase.module.css';
+import baseStyles from '../styles/HelldiversBase.module.css';
 import styles from '@/components/profile/Profile.module.css';
 
 import ProfileHeader from '@/components/profile/ProfileHeader';

--- a/src/app/(main)/helldivers-2/settings/page.tsx
+++ b/src/app/(main)/helldivers-2/settings/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import baseStyles from "../helldivers-2/HelldiversBase.module.css";
-import styles from './Settings.module.css';
+import baseStyles from "../styles/HelldiversBase.module.css";
+import styles from './SettingsPage.module.css';
 import ProfileEditForm from "@/components/profile/ProfileEditForm";
 
 export default function SettingsPage() {

--- a/src/app/(main)/helldivers-2/styles/HelldiversBase.module.css
+++ b/src/app/(main)/helldivers-2/styles/HelldiversBase.module.css
@@ -1,0 +1,136 @@
+.wrapper {
+  position: relative;
+  background: var(--color-background-alt, transparent);
+  min-height: 100vh;
+}
+
+.dividerLayer {
+  position: absolute;
+  inset: 0;
+  background: var(--color-background-alt, #05080f);
+  opacity: 0.9;
+  z-index: 0;
+}
+
+.pageContainer {
+  position: relative;
+  z-index: 1;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  color: var(--color-text-primary, #f9fafb);
+}
+
+.section {
+  margin-bottom: 3rem;
+  padding: 2rem;
+  background: var(--color-surface, rgba(15, 23, 42, 0.65));
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.35));
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.45);
+}
+
+.sectionTitle {
+  font-size: clamp(1.5rem, 4vw, 1.875rem);
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: var(--color-primary, #60a5fa);
+  border-bottom: 1px solid var(--color-border, rgba(148, 163, 184, 0.35));
+  padding-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  scroll-margin-top: 84px;
+}
+
+.subHeading {
+  font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+  font-weight: 600;
+  color: var(--color-text-primary, #f9fafb);
+  margin: 1.75rem 0 1rem;
+}
+
+.subsectionCard {
+  background: var(--color-surface, rgba(17, 24, 39, 0.8));
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.35));
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 10px 25px rgba(2, 6, 23, 0.35);
+}
+
+.paragraph {
+  color: var(--color-text-secondary, #cbd5f5);
+  margin-bottom: 1.25rem;
+  line-height: 1.75;
+  font-size: clamp(0.95rem, 2vw, 1rem);
+}
+
+.strongText {
+  font-weight: 700;
+  color: var(--color-primary, #60a5fa);
+}
+
+.styledList {
+  margin: 0;
+  padding-left: 1.25rem;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-text-secondary, #cbd5f5);
+}
+
+.decimal {
+  list-style: decimal;
+}
+
+.listItem {
+  line-height: 1.7;
+}
+
+.ruleList {
+  counter-reset: rule-counter;
+  list-style: none;
+  margin: 1rem 0 1.5rem;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ruleListItem {
+  position: relative;
+  padding-left: 2.25rem;
+  line-height: 1.7;
+}
+
+.ruleListItem::before {
+  counter-increment: rule-counter;
+  content: counter(rule-counter);
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--color-primary, #60a5fa);
+  color: #05080f;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  box-shadow: 0 6px 16px rgba(2, 6, 23, 0.35);
+}
+
+@media (max-width: 768px) {
+  .section {
+    padding: 1.5rem;
+  }
+
+  .pageContainer {
+    padding: 2.5rem 1rem 3rem;
+  }
+
+  .subsectionCard {
+    padding: 1.25rem;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 // src/app/layout.tsx
-/* eslint-disable @next/next/no-img-element */
 'use client';
 
 import 'swiper/css';

--- a/src/components/academy/ModuleCard.tsx
+++ b/src/components/academy/ModuleCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import base from '../HelldiversBase.module.css';
+import base from '@/app/(main)/helldivers-2/styles/HelldiversBase.module.css';
 import styles from './ModuleCard.module.css';
 import type { AcademyModule } from '@/components/academy/Modules';
 

--- a/src/components/campaigns/YoutubeCarouselCampaign.module.css
+++ b/src/components/campaigns/YoutubeCarouselCampaign.module.css
@@ -1,0 +1,35 @@
+.youtubePlaceholder {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  color: var(--color-text-secondary, #cbd5f5);
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.youtubePlaceholderTitle {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--color-text-primary, #f8fafc);
+}
+
+.youtubePlaceholderText {
+  margin: 0;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.youtubePlaceholderText span {
+  font-weight: 600;
+  color: var(--color-primary, #60a5fa);
+}
+
+@media (max-width: 768px) {
+  .youtubePlaceholder {
+    padding: 1.5rem 1.25rem;
+    font-size: 0.9rem;
+  }
+}

--- a/src/components/campaigns/YoutubeCarouselCampaign.tsx
+++ b/src/components/campaigns/YoutubeCarouselCampaign.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from 'react';
 import YoutubeCarousel, { YoutubeVideo } from '../home/YoutubeCarousel';
-import styles from './HelldiversBase.module.css';
+import styles from './YoutubeCarouselCampaign.module.css';
 
 function extractYouTubeId(url: string): string | null {
   try {

--- a/src/components/challenges/YoutubeCarouselChallenges copy.tsx
+++ b/src/components/challenges/YoutubeCarouselChallenges copy.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from 'react';
 import YoutubeCarousel, { YoutubeVideo } from '../home/YoutubeCarousel';
-import styles from './HelldiversBase.module.css';
+import styles from '../campaigns/YoutubeCarouselCampaign.module.css';
 
 function extractYouTubeId(url: string): string | null {
   try {

--- a/src/components/common/CodeBlocks.module.css
+++ b/src/components/common/CodeBlocks.module.css
@@ -1,0 +1,26 @@
+.codeBlock {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  color: var(--color-text-primary, #f8fafc);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+  font-size: 0.9rem;
+  line-height: 1.7;
+  padding: 1.25rem 1.5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  background-image: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(99, 102, 241, 0.08));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 20px 45px rgba(2, 6, 23, 0.45);
+}
+
+.codeBlock code {
+  font-family: inherit;
+}
+
+@media (max-width: 768px) {
+  .codeBlock {
+    padding: 1rem 1.25rem;
+    font-size: 0.85rem;
+  }
+}

--- a/src/components/common/NoPrefetchLink.tsx
+++ b/src/components/common/NoPrefetchLink.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Link, { type LinkProps } from 'next/link';
+import { type AnchorHTMLAttributes, type PropsWithChildren } from 'react';
+
+// Anchor attributes except href (handled by LinkProps)
+type AnchorExtras = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
+
+type NoPrefetchLinkProps = PropsWithChildren<LinkProps & AnchorExtras>;
+
+export default function NoPrefetchLink({
+  children,
+  prefetch: _prefetch,
+  ...rest
+}: NoPrefetchLinkProps) {
+  return (
+    <Link {...rest} prefetch={false}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/home/ReviewsRotator.tsx
+++ b/src/components/home/ReviewsRotator.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FaStar } from 'react-icons/fa';
-import styles from '@/app/components/Reviews.module.css';
+import styles from './Reviews.module.css';
 
 export interface Review {
   id: number | string;

--- a/src/components/home/YoutubeCarousel.tsx
+++ b/src/components/home/YoutubeCarousel.tsx
@@ -7,7 +7,7 @@ import { Navigation, EffectFade } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/effect-fade';
-import styles from './HelldiversBase.module.css';
+import styles from './YouTubeCarousel.module.css';
 
 export interface YoutubeVideo {
   id: string;

--- a/src/components/profile/Profile.module.css
+++ b/src/components/profile/Profile.module.css
@@ -1,0 +1,198 @@
+.gridContainer {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .gridContainer {
+    grid-template-columns: 280px 1fr;
+    align-items: flex-start;
+  }
+}
+
+.content {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 1.75rem;
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.45);
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (max-width: 768px) {
+  .content {
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+}
+
+.contentTitle {
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-weight: 600;
+  color: var(--color-primary, #60a5fa);
+  margin-bottom: 1rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--color-text-primary, #f8fafc);
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  text-transform: uppercase;
+}
+
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.statCard {
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.statLabel {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.statValue {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #f8fafc);
+}
+
+.profileHeader {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(99, 102, 241, 0.08));
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.4);
+}
+
+.avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid rgba(96, 165, 250, 0.65);
+  box-shadow: 0 15px 35px rgba(2, 6, 23, 0.45);
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profileInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.profileName {
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  font-weight: 700;
+  color: var(--color-text-primary, #f8fafc);
+  margin: 0;
+}
+
+.profileSubtitle {
+  margin: 0;
+  color: rgba(191, 219, 254, 0.9);
+  font-size: 0.95rem;
+}
+
+.profileActions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary, #60a5fa);
+  color: #05080f;
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  border: none;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.45);
+}
+
+.button:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.7);
+  outline-offset: 3px;
+}
+
+.sidebar {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  background: rgba(17, 24, 39, 0.75);
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  border-radius: 0.75rem;
+  height: fit-content;
+}
+
+.sidebarButton {
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid transparent;
+  color: var(--color-text-secondary, #cbd5f5);
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.6rem;
+  font-weight: 600;
+  text-align: left;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+}
+
+.sidebarButton[aria-pressed='true'] {
+  border-color: rgba(96, 165, 250, 0.65);
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--color-text-primary, #f8fafc);
+  transform: translateX(4px);
+}
+
+.sidebarButton:hover {
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+@media (max-width: 1023px) {
+  .sidebar {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .sidebarButton {
+    text-align: center;
+  }
+}

--- a/src/components/profile/SidebarTabs.tsx
+++ b/src/components/profile/SidebarTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import styles from '@/app/(main)/profile/Profile.module.css';
+import styles from '@/components/profile/Profile.module.css';
 
 export type InfoTab =
   | 'roles'

--- a/src/models/ForumCategory.ts
+++ b/src/models/ForumCategory.ts
@@ -1,0 +1,27 @@
+import { Schema, models, model, type Model, type Document } from 'mongoose';
+
+export interface ForumCategoryDocument extends Document {
+  name: string;
+  description?: string;
+  slug?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ForumCategorySchema = new Schema<ForumCategoryDocument>(
+  {
+    name: { type: String, required: true, trim: true },
+    description: { type: String, default: '' },
+    slug: { type: String, trim: true, index: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+ForumCategorySchema.index({ slug: 1 }, { unique: true, sparse: true });
+
+const ForumCategoryModel: Model<ForumCategoryDocument> =
+  models.ForumCategory || model<ForumCategoryDocument>('ForumCategory', ForumCategorySchema);
+
+export default ForumCategoryModel;

--- a/src/models/ForumPost.ts
+++ b/src/models/ForumPost.ts
@@ -1,0 +1,28 @@
+import { Schema, models, model, type Model, type Document, Types } from 'mongoose';
+
+export interface ForumPostDocument extends Document {
+  threadId: Types.ObjectId;
+  authorId: Types.ObjectId | string;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ForumPostSchema = new Schema<ForumPostDocument>(
+  {
+    threadId: { type: Schema.Types.ObjectId, ref: 'ForumThread', required: true },
+    authorId: { type: Schema.Types.Mixed, required: true },
+    content: { type: String, required: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+ForumPostSchema.index({ threadId: 1, createdAt: 1 });
+ForumPostSchema.index({ authorId: 1, createdAt: -1 });
+
+const ForumPostModel: Model<ForumPostDocument> =
+  models.ForumPost || model<ForumPostDocument>('ForumPost', ForumPostSchema);
+
+export default ForumPostModel;

--- a/src/models/ForumThread.ts
+++ b/src/models/ForumThread.ts
@@ -1,0 +1,30 @@
+import { Schema, models, model, type Model, type Document, Types } from 'mongoose';
+
+export interface ForumThreadDocument extends Document {
+  title: string;
+  body?: string;
+  categoryId: Types.ObjectId;
+  authorId: Types.ObjectId | string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ForumThreadSchema = new Schema<ForumThreadDocument>(
+  {
+    title: { type: String, required: true, trim: true },
+    body: { type: String, default: '' },
+    categoryId: { type: Schema.Types.ObjectId, ref: 'ForumCategory', required: true },
+    authorId: { type: Schema.Types.Mixed, required: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+ForumThreadSchema.index({ categoryId: 1, createdAt: -1 });
+ForumThreadSchema.index({ authorId: 1, createdAt: -1 });
+
+const ForumThreadModel: Model<ForumThreadDocument> =
+  models.ForumThread || model<ForumThreadDocument>('ForumThread', ForumThreadSchema);
+
+export default ForumThreadModel;


### PR DESCRIPTION
## Summary
- add a minimal .dockerignore so CSS modules are shipped into the container build context
- move shared Helldivers styles into a dedicated styles module and fix imports to use the @ alias plus new CodeBlocks/YouTube CSS modules
- add the missing NoPrefetchLink helper and forum mongoose models while wiring eslint-plugin-import for case-sensitive import checks

## Testing
- pnpm install
- pnpm run lint
- pnpm run build *(fails: blocked from downloading Google Fonts in the sandbox)*
- docker build -t helldivers-debug . *(fails: docker binary unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceeeaf3f94832fa178e72e76dd5b6d